### PR TITLE
CL argument changed to allow disabling CUDA

### DIFF
--- a/BERT_Model.py
+++ b/BERT_Model.py
@@ -538,7 +538,7 @@ if __name__=='__main__':
     
     parser = argparse.ArgumentParser(description='WSD using BERT')
     
-    parser.add_argument('--use_cuda', type=bool, default=True, help='Use GPU?')
+    parser.add_argument('--no_cuda', action='store_false', help='Use GPU?')
     parser.add_argument('--device', type=str, default='cuda:2', help='GPU Device to Use?')
     parser.add_argument('--train_corpus', type=str, required=True, help='Training Corpus')
     parser.add_argument('--train_type', type=str, required=True, help='SEM/WNGT/SE')
@@ -556,7 +556,13 @@ if __name__=='__main__':
     print("Testing Corpus is:  " + args.test_corpus)
     print("Nearest Neighbour start: " + str(args.start_k))
     print("Nearest Neighbour end: " + str(args.end_k))
-    
+
+    if args.no_cuda:
+        print("Processing with CUDA!")
+
+    else:
+        print("Processing without CUDA!")
+
     if args.reduced_search:
         print("Using Reduced POS Search!")
     
@@ -571,7 +577,7 @@ if __name__=='__main__':
     
     print("Loading WSD Model!")
     
-    WSD = Word_Sense_Model(device_number = args.device, use_cuda = args.use_cuda)
+    WSD = Word_Sense_Model(device_number=args.device, use_cuda=args.no_cuda)
     
     print("Loaded WSD Model!")
     

--- a/Flair_Model.py
+++ b/Flair_Model.py
@@ -482,7 +482,7 @@ if __name__=='__main__':
     
     parser = argparse.ArgumentParser(description='WSD using Flair')
     
-    parser.add_argument('--use_cuda', type=bool, default=True, help='Use GPU?')
+    parser.add_argument('--no_cuda', action='store_false', help='Use GPU?')
     parser.add_argument('--device', type=str, default='cuda:2', help='GPU Device to Use?')
     parser.add_argument('--train_corpus', type=str, required=True, help='Training Corpus')
     parser.add_argument('--train_type', type=str, required=True, help='SEM/WNGT/SE')
@@ -501,6 +501,12 @@ if __name__=='__main__':
     print("Nearest Neighbour start: " + str(args.start_k))
     print("Nearest Neighbour end: " + str(args.end_k))
     
+    if args.no_cuda:
+        print("Processing with CUDA!")
+
+    else:
+        print("Processing without CUDA!")
+
     if args.reduced_search:
         print("Using Reduced POS Search!")
     
@@ -515,7 +521,7 @@ if __name__=='__main__':
     
     print("Loading WSD Model!")
     
-    WSD = Word_Sense_Model(device_number = args.device, use_cuda = args.use_cuda)
+    WSD = Word_Sense_Model(device_number = args.device, use_cuda = args.no_cuda)
     
     print("Loaded WSD Model!")
     

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ The steps to carry out the experiments are same for all the files. We shall demo
 
 Run `python BERT_Model.py` with the following main arguments:
 
- - `--use_cuda [True|False]`: (default True) provide whether you want to switch the training to GPU or not.
  - `--device [cuda:0 | cuda:1 ...]` : (default 'cuda:2') Specify the device number on GPU you want to load the BERT model to and do the training.
  - `--train_corpus [FILE_NAME]`: This is the path to your training file.
  - `--train_type [SE|SEM|WNGT]`: Specify this argument depending upon the dataset you are using for training. (The values are case-sensitive).
@@ -79,11 +78,11 @@ Below, we provide two examples to understand how to use the arguments mentioned 
 
  1. To generate the results for SE-2 as mentioned in Table 3 of the paper, run the `BERT_Model.py` file as follows: 
  
- `python BERT_Model.py --use_cuda=True --device=cuda:0 --train_corpus=senseval2_lexical_sample_train.xml trained_pickle=BERT_embs.pickle --test_corpus=senseval2_lexical_sample_test.xml --start_k=1 --end_k=10 --save_xml_to=SE2.xml --use_euclidean=0 --reduced_search=0`
+ `python BERT_Model.py --device=cuda:0 --train_corpus=senseval2_lexical_sample_train.xml trained_pickle=BERT_embs.pickle --test_corpus=senseval2_lexical_sample_test.xml --start_k=1 --end_k=10 --save_xml_to=SE2.xml --use_euclidean=0 --reduced_search=0`
 
 2. To generate the results for S7-T7 on WNGT as mentioned in Table 5 of the paper, run the `BERT_Model.py` file as follows: 
 
- `python BERT_Model.py --use_cuda=True --device=cuda:0 --train_corpus=wngt.xml trained_pickle=WNGT_BERT_embs.pickle --test_corpus=semeval2007task7.xml --start_k=1 --end_k=10 --save_xml_to=SE7T17.xml --use_euclidean=0 --reduced_search=1`
+ `python BERT_Model.py --device=cuda:0 --train_corpus=wngt.xml trained_pickle=WNGT_BERT_embs.pickle --test_corpus=semeval2007task7.xml --start_k=1 --end_k=10 --save_xml_to=SE7T17.xml --use_euclidean=0 --reduced_search=1`
 
 ## Evaluation
 


### PR DESCRIPTION
With current argument, `use_cuda=False` has no effect.

Changed `use_cuda` argument to `no_cuda`, so that CUDA can be disabled. Affects both BERT_Model.py and Flair_Model.py

Changed README accordingly.